### PR TITLE
Feat: Member 조회 API 수정 및 DDL 옵션 변경

### DIFF
--- a/src/main/java/crush/myList/config/setup/DummyData.java
+++ b/src/main/java/crush/myList/config/setup/DummyData.java
@@ -39,10 +39,15 @@ public class DummyData {
                 .name("tester")
                 .build();
 
-        memberRepository.save(kwangstar);
-        memberRepository.save(yunseong);
-        memberRepository.save(donghyun);
-        memberRepository.save(test);
+        try {
+            memberRepository.save(kwangstar);
+            memberRepository.save(yunseong);
+            memberRepository.save(donghyun);
+            memberRepository.save(test);
+        }
+        catch (Exception e) {
+            System.out.println("이미 존재하는 회원 더미 입니다.");
+        }
     }
 
     public void setupPlaylist() {
@@ -57,7 +62,11 @@ public class DummyData {
                     .member(kwangstar)
                     .name("kwangstar playlist " + i)
                     .build();
-            playlistRepository.save(playlist);
+            try {
+                playlistRepository.save(playlist);
+            } catch (Exception e) {
+                System.out.println(playlist.getName() + ": 이미 존재하는 플레이리스트 더미 입니다.");
+            }
         }
         // yunseong
         for (int i=1; i<=10; i++) {
@@ -65,7 +74,11 @@ public class DummyData {
                     .member(yunseong)
                     .name("yunseong playlist " + i)
                     .build();
-            playlistRepository.save(playlist);
+            try {
+                playlistRepository.save(playlist);
+            } catch (Exception e) {
+                System.out.println(playlist.getName() + ": 이미 존재하는 플레이리스트 더미 입니다.");
+            }
         }
         // donghyun
         for (int i=1; i<=10; i++) {
@@ -73,7 +86,11 @@ public class DummyData {
                     .member(donghyun)
                     .name("donghyun playlist " + i)
                     .build();
-            playlistRepository.save(playlist);
+            try {
+                playlistRepository.save(playlist);
+            } catch (Exception e) {
+                System.out.println(playlist.getName() + ": 이미 존재하는 플레이리스트 더미 입니다.");
+            }
         }
         // test
         for (int i=1; i<=10; i++) {
@@ -81,13 +98,21 @@ public class DummyData {
                     .member(test)
                     .name("test playlist " + i)
                     .build();
-            playlistRepository.save(playlist);
+            try {
+                playlistRepository.save(playlist);
+            } catch (Exception e) {
+                System.out.println(playlist.getName() + ": 이미 존재하는 플레이리스트 더미 입니다.");
+            }
         }
     }
 
     @PostConstruct
     public void setupDummyData() {
-        setupMember();
-        setupPlaylist();
+        try {
+            setupMember();
+            setupPlaylist();
+        } catch (Exception e) {
+            System.out.println("더미 데이터 초기화 실패.");
+        }
     }
 }

--- a/src/main/java/crush/myList/domain/member/controller/MemberController.java
+++ b/src/main/java/crush/myList/domain/member/controller/MemberController.java
@@ -37,15 +37,27 @@ public class MemberController {
         return JsonBody.of(HttpStatus.OK.value(), "회원 정보 수정 성공", res);
     }
 
-    @Operation(summary = "특정 회원 정보 조회")
+    @Operation(summary = "id로 특정 회원 정보 조회")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "회원 정보 조회 성공", content = {@Content(mediaType = "application/json",
                     schema = @Schema(implementation = MemberDto.class))}),
             @ApiResponse(responseCode = "404", description = "회원 정보 조회 실패", content = {@Content(mediaType = "application/json")})
     })
-    @GetMapping("/{id}")
+    @GetMapping("/id/{id}")
     public JsonBody<MemberDto> getMember(@PathVariable Long id) {
         MemberDto memberDto = memberService.getMember(id);
+        return JsonBody.of(HttpStatus.OK.value(), "회원 정보 조회 성공", memberDto);
+    }
+
+    @Operation(summary = "닉네임으로 특정 회원 정보 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "회원 정보 조회 성공", content = {@Content(mediaType = "application/json",
+                    schema = @Schema(implementation = MemberDto.class))}),
+            @ApiResponse(responseCode = "404", description = "회원 정보 조회 실패", content = {@Content(mediaType = "application/json")})
+    })
+    @GetMapping("/nickname/{username}")
+    public JsonBody<MemberDto> getMember(@PathVariable String username) {
+        MemberDto memberDto = memberService.getMember(username);
         return JsonBody.of(HttpStatus.OK.value(), "회원 정보 조회 성공", memberDto);
     }
 

--- a/src/main/java/crush/myList/domain/member/service/MemberService.java
+++ b/src/main/java/crush/myList/domain/member/service/MemberService.java
@@ -114,4 +114,11 @@ public class MemberService {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."));
         return convertDto(member);
     }
+
+    /** username을 기준으로 사용자 조회 */
+    public MemberDto getMember(String username) {
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."));
+        return convertDto(member);
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,7 +14,7 @@ spring:
     open-in-view: false
     hibernate:
       ddl-auto: create-drop
-    show-sql: true
+    show-sql: false
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
   jpa:
     open-in-view: false
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     show-sql: false
     properties:
       hibernate:

--- a/src/test/java/crush/myList/controller/MemberControllerTest.java
+++ b/src/test/java/crush/myList/controller/MemberControllerTest.java
@@ -102,7 +102,7 @@ public class MemberControllerTest {
     }
 
     @Test
-    @DisplayName("회원 정보 조회 테스트")
+    @DisplayName("회원 정보 조회 테스트 - id로 조회")
     void viewMemberInfoTest(TestReporter testReporter) throws Exception {
         // given
         Member member = Member.builder()
@@ -112,7 +112,24 @@ public class MemberControllerTest {
                 .build();
         memberRepository.save(member);
         // when
-        testReporter.publishEntry(mvc.perform(get("/api/v1/member/{id}", member.getId())
+        testReporter.publishEntry(mvc.perform(get("/api/v1/member/id/{id}", member.getId())
+                .header("Authorization", "Bearer " + jwtTokenProvider.createToken(member.getId().toString(), JwtTokenType.ACCESS_TOKEN)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString());
+    }
+
+    @Test
+    @DisplayName("회원 정보 조회 테스트 - 닉네임으로 조회")
+    void viewMemberInfoTest2(TestReporter testReporter) throws Exception {
+        // given
+        Member member = Member.builder()
+                .oauth2id("1")
+                .username("test")
+                .name("test1")
+                .build();
+        memberRepository.save(member);
+        // when
+        testReporter.publishEntry(mvc.perform(get("/api/v1/member/nickname/{username}", member.getUsername())
                 .header("Authorization", "Bearer " + jwtTokenProvider.createToken(member.getId().toString(), JwtTokenType.ACCESS_TOKEN)))
                 .andExpect(status().isOk())
                 .andReturn().getResponse().getContentAsString());


### PR DESCRIPTION
## PR Checklist
아래의 조건을 확인하고 체크박스를 체크해주세요. 체크박스를 체크하지 않은 경우 PR이 머지되지 않을 수 있습니다.

- [x] 커밋 컨벤션을 지켜서 작성했는가?
- [ ] 기능 추가의 경우 테스트 코드를 작성했는가?
- [x] 기능 변경의 경우 문서를 업데이트했는가?
- [ ] 코드 리뷰를 진행했는가?


## PR Type
어떤 종류의 PR인지 체크박스를 체크해주세요.

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes


## What is the current behavior?
- JPA의 ddl-auto 값이 create-drop
- 사용자 id로 조회하는 api만 존재

## What is the new behavior?
- JPA ddl-auto 옵션을 update로 변경
- 사용자 닉네임으로 조회하는 api 추가


## Other information
ddl-auto
![image](https://github.com/CUK-CRUSH/Server/assets/71076926/868a2aa8-e84b-4653-84eb-21eee2e7eba7)

사용자 조회 엔드포인트 수정
![image](https://github.com/CUK-CRUSH/Server/assets/71076926/91a7c7d4-bc57-4b2d-a8c6-a047d338f6d6)
****