### PR TITLE
Refactor: Playlist PATCH 리퀘스트 필드 선택사항으로 변경 + 널값 검증

### DIFF
--- a/src/main/java/crush/myList/domain/playlist/controller/PlaylistController.java
+++ b/src/main/java/crush/myList/domain/playlist/controller/PlaylistController.java
@@ -6,7 +6,6 @@ import crush.myList.domain.playlist.service.PlaylistService;
 import crush.myList.global.dto.JsonBody;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -15,7 +14,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -49,13 +47,13 @@ public class PlaylistController {
             @ApiResponse(responseCode = "404", description = "인증 문제 발생", content = @Content(schema = @Schema(hidden = true)))
     })
     public JsonBody<PlaylistDto.Response> addPlaylist(
-            @ModelAttribute PlaylistDto.Request request,
+            @ModelAttribute PlaylistDto.PostRequest postRequest,
             @AuthenticationPrincipal SecurityMember member
             ) {
         return JsonBody.of(
                 HttpStatus.OK.value(),
                 "플레이리스트 생성 성공",
-                playlistService.addPlaylist(member, request)
+                playlistService.addPlaylist(member, postRequest)
         );
     }
 
@@ -69,12 +67,12 @@ public class PlaylistController {
     public JsonBody<PlaylistDto.Response> updatePlaylist(
             @AuthenticationPrincipal SecurityMember member,
             @PathVariable Long playlistId,
-            @ModelAttribute PlaylistDto.Request request
+            @ModelAttribute PlaylistDto.PatchRequest patchRequest
     ) {
         return JsonBody.of(
                 HttpStatus.OK.value(),
                 "플레이리스트 수정 완료",
-                playlistService.updatePlaylist(member, playlistId, request)
+                playlistService.updatePlaylist(member, playlistId, patchRequest)
         );
     }
 

--- a/src/main/java/crush/myList/domain/playlist/dto/PlaylistDto.java
+++ b/src/main/java/crush/myList/domain/playlist/dto/PlaylistDto.java
@@ -13,10 +13,24 @@ public class PlaylistDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    @Schema(name = "PlaylistDtoRequest", description = "플레이리스트 추가 요청", type = "multipartForm")
-    public static class Request {
+    @Schema(name = "PlaylistPostRequest", description = "플레이리스트 추가 요청", type = "multipartForm")
+    public static class PostRequest {
         @Schema(name = "playlistName", description = "플레이리스트 이름입니다.")
         @NotBlank
+        private String playlistName;
+
+        @Schema(name = "titleImage", description = "플레이리스트 이미지입니다.", type = "string", format = "binary")
+        private MultipartFile titleImage;
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(name = "PlaylistPatchRequest", description = "플레이리스트 수정 요청", type = "multipartForm")
+    public static class PatchRequest {
+        @Schema(name = "playlistName", description = "플레이리스트 이름입니다.")
         private String playlistName;
 
         @Schema(name = "titleImage", description = "플레이리스트 이미지입니다.", type = "string", format = "binary")

--- a/src/main/java/crush/myList/domain/playlist/service/PlaylistService.java
+++ b/src/main/java/crush/myList/domain/playlist/service/PlaylistService.java
@@ -2,7 +2,6 @@ package crush.myList.domain.playlist.service;
 
 import crush.myList.config.security.SecurityMember;
 import crush.myList.domain.image.entity.Image;
-import crush.myList.domain.image.repository.ImageRepository;
 import crush.myList.domain.image.service.ImageService;
 import crush.myList.domain.member.entity.Member;
 import crush.myList.domain.member.repository.MemberRepository;
@@ -28,7 +27,6 @@ import java.util.Objects;
 public class PlaylistService {
     private final PlaylistRepository playlistRepository;
     private final MemberRepository memberRepository;
-    private final ImageRepository imageRepository;
     private final MusicRepository musicRepository;
 
     private final ImageService imageService;

--- a/src/main/java/crush/myList/domain/playlist/service/PlaylistService.java
+++ b/src/main/java/crush/myList/domain/playlist/service/PlaylistService.java
@@ -80,7 +80,9 @@ public class PlaylistService {
         MultipartFile imageFile = patchRequest.getTitleImage();
 
         if (imageFile != null && !imageFile.isEmpty()) {
-            imageService.deleteImageToGcs(playlist.getImage().getId());
+            if (playlist.getImage() != null) {
+                imageService.deleteImageToGcs(playlist.getImage().getId());
+            }
             Image newImage = imageService.saveImageToGcs_Image(imageFile);
 
             playlist.setImage(newImage);


### PR DESCRIPTION
## PR Checklist
아래의 조건을 확인하고 체크박스를 체크해주세요. 체크박스를 체크하지 않은 경우 PR이 머지되지 않을 수 있습니다.

- [X] 커밋 컨벤션을 지켜서 작성했는가?
- [ ] 기능 추가의 경우 테스트 코드를 작성했는가?
- [ ] 기능 변경의 경우 문서를 업데이트했는가?
- [ ] 코드 리뷰를 진행했는가?


## PR Type
어떤 종류의 PR인지 체크박스를 체크해주세요.

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes


## What is the current behavior?
플레이리스트 수정 기능에 필수 필드 존재
플레이리스트 이미지 수정 시 원래 이미지 널값 검증 없이 삭제

## What is the new behavior?
플레이리스트 수정 기능에 선택적 필드로 교체
플레이리스트 이미지 수정 시 원래 이미지 널값 검증 후 삭제



## Other information

<img width="950" alt="스크린샷 2024-01-23 오후 1 32 24" src="https://github.com/CUK-CRUSH/Server/assets/62097643/45fbefa5-96ed-4f12-ada3-83bc89c05a44">

POST 객체와 PATCH 객체 구별하여 PATCH 메소드 시 playlistName 필드가 필수가 아니도록 함

<img width="658" alt="스크린샷 2024-01-23 오후 1 33 47" src="https://github.com/CUK-CRUSH/Server/assets/62097643/1c19c479-6ded-406d-b3f6-ec4f2e27f5d5">

플레이리스트가 원래 이미지가 없는 경우에 수정할 때 널값 검증으로 널포인터 오류 방지