### PR TITLE
Fix: 플레이리스트 단일조회 api 302오류 수정

### DIFF
--- a/src/main/java/crush/myList/config/security/SecurityConfig.java
+++ b/src/main/java/crush/myList/config/security/SecurityConfig.java
@@ -36,6 +36,7 @@ public class SecurityConfig {
     private final String[] GET_LIST = {
         // 플레이리스트 조회 api
         "/api/v1/playlist/user/{username}",
+        "/api/v1/playlist/{playlistId}",
         // 음악 조회 api
         "/api/v1/music/{playlistId}",
         // 사용자 조회 api

--- a/src/test/java/crush/myList/controller/PlaylistControllerTest.java
+++ b/src/test/java/crush/myList/controller/PlaylistControllerTest.java
@@ -47,7 +47,45 @@ public class PlaylistControllerTest {
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
 
-    @DisplayName("플레이리스트 조회 테스트")
+    @DisplayName("사용자의 모든 플레이리스트 조회 테스트")
+    @Test
+    public void viewAllPlaylistsTest(TestReporter testReporter) throws Exception {
+        // given
+        Role role = roleRepository.findByName(RoleName.USER)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 권한입니다."));
+        Member member = Member.builder()
+                .oauth2id("1")
+                .username("test")
+                .name("test1")
+                .role(role)
+                .build();
+        memberRepository.save(member);
+
+        Playlist playlist = Playlist.builder()
+                .name("testPlaylistName")
+                .member(member)
+                .build();
+        playlistRepository.save(playlist);
+
+        Music music = Music.builder()
+                .title("굿굿")
+                .artist("후후")
+                .url("https://youtube.com")
+                .playlist(playlist)
+                .build();
+        musicRepository.save(music);
+
+        final String api = "/api/v1/playlist/user/" + member.getUsername();
+
+        // when
+        testReporter.publishEntry(
+                mockMvc.perform(get(api))
+                        .andExpect(status().isOk())
+                        .andReturn().getResponse().getContentAsString()
+        );
+    }
+
+    @DisplayName("플레이리스트 단일 조회 테스트")
     @Test
     public void viewPlaylistTest(TestReporter testReporter) throws Exception {
         // given
@@ -75,7 +113,7 @@ public class PlaylistControllerTest {
                 .build();
         musicRepository.save(music);
 
-        final String api = "/api/v1/playlist/user/" + member.getUsername();
+        final String api = "/api/v1/playlist/" + playlist.getId();
 
         // when
         testReporter.publishEntry(


### PR DESCRIPTION
## PR Checklist
아래의 조건을 확인하고 체크박스를 체크해주세요. 체크박스를 체크하지 않은 경우 PR이 머지되지 않을 수 있습니다.

- [x] 커밋 컨벤션을 지켜서 작성했는가?
- [x] 기능 추가의 경우 테스트 코드를 작성했는가?
- [ ] 기능 변경의 경우 문서를 업데이트했는가?
- [ ] 코드 리뷰를 진행했는가?


## PR Type
어떤 종류의 PR인지 체크박스를 체크해주세요.

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes


## What is the current behavior?
- 플레이리스트 단일조회 302 에러

## What is the new behavior?
- 플레이리스트 단일조회 경로 white list 추가


## Other information
![image](https://github.com/CUK-CRUSH/Server/assets/71076926/97df55b8-7d29-4fe9-92ea-4c25566dd644)
