### PR TITLE
Fix: 비속어 검사 메소드에서 BAD_REQUEST가 INTERNAL_SERVER_ERROR로 전송하던 버그 해결

### DIFF
--- a/src/main/java/crush/myList/domain/member/service/UsernameService.java
+++ b/src/main/java/crush/myList/domain/member/service/UsernameService.java
@@ -42,7 +42,10 @@ public class UsernameService {
             }
         } catch (NullPointerException e) {
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "통신에 실패했습니다");
+        } catch (ResponseStatusException e) {
+            throw e;
         } catch (Exception e) {
+            log.error(e.getMessage());
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 오류가 발생했습니다.");
         }
     }

--- a/src/main/java/crush/myList/domain/member/service/UsernameService.java
+++ b/src/main/java/crush/myList/domain/member/service/UsernameService.java
@@ -45,7 +45,6 @@ public class UsernameService {
         } catch (ResponseStatusException e) {
             throw e;
         } catch (Exception e) {
-            log.error(e.getMessage());
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 오류가 발생했습니다.");
         }
     }


### PR DESCRIPTION
## PR Checklist
아래의 조건을 확인하고 체크박스를 체크해주세요. 체크박스를 체크하지 않은 경우 PR이 머지되지 않을 수 있습니다.

- [X] 커밋 컨벤션을 지켜서 작성했는가?
- [ ] 기능 추가의 경우 테스트 코드를 작성했는가?
- [ ] 기능 변경의 경우 문서를 업데이트했는가?
- [x] 코드 리뷰를 진행했는가?


## PR Type
어떤 종류의 PR인지 체크박스를 체크해주세요.

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes


## What is the current behavior?
400 에러가 500으로 감.

## What is the new behavior?
catch문을 분리하여 버그 해결


## Other information
이미지와 같은 PR과 관련된 추가적인 정보가 있다면 작성해주세요.
<img width="1006" alt="스크린샷 2024-01-31 오후 2 21 25" src="https://github.com/CUK-CRUSH/Server/assets/62097643/0eaf5a2d-dc28-4d09-8879-01ade1be006a">

메소드 내부 try-catch 문 