### PR TITLE
[프론트 요청] 플레이리스트 조회 시 유저네임 필드 추가

### DIFF
--- a/src/main/java/crush/myList/domain/playlist/dto/PlaylistDto.java
+++ b/src/main/java/crush/myList/domain/playlist/dto/PlaylistDto.java
@@ -53,6 +53,10 @@ public class PlaylistDto {
         @NotEmpty
         private String playlistName;
 
+        @Schema(name = "username", description = "플레이리스트 생성자 이름입니다.")
+        @NotEmpty
+        private String username;
+
         @Schema(name = "thumbnailUrl", description = "썸네일 이미지 주소입니다.")
         private String thumbnailUrl;
 

--- a/src/main/java/crush/myList/domain/playlist/service/LikeService.java
+++ b/src/main/java/crush/myList/domain/playlist/service/LikeService.java
@@ -95,6 +95,7 @@ public class LikeService {
                 .map(playlist -> PlaylistDto.Response.builder()
                         .id(playlist.getId())
                         .playlistName(playlist.getName())
+                        .username(playlist.getMember().getUsername())
                         .numberOfMusics(playlist.getMusics() == null ? 0 : playlist.getMusics().size())
                         .thumbnailUrl(playlist.getImage() != null ? playlist.getImage().getUrl() : null)
                         .likeCount(playlistLikeRepository.countByPlaylistId(playlist.getId()))

--- a/src/main/java/crush/myList/domain/playlist/service/PlaylistService.java
+++ b/src/main/java/crush/myList/domain/playlist/service/PlaylistService.java
@@ -156,6 +156,7 @@ public class PlaylistService {
         return PlaylistDto.Response.builder()
                 .id(playlist.getId())
                 .playlistName(playlist.getName())
+                .username(playlist.getMember().getUsername())
                 .thumbnailUrl(playlist.getImage() != null ? playlist.getImage().getUrl() : null)
                 // counts musics in playlist
                 .numberOfMusics(musicRepository.countByPlaylist(playlist))

--- a/src/test/java/crush/myList/controller/PlaylistControllerTest.java
+++ b/src/test/java/crush/myList/controller/PlaylistControllerTest.java
@@ -53,6 +53,8 @@ public class PlaylistControllerTest {
         testReporter.publishEntry(
                 mockMvc.perform(get(api))
                         .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data[0].id").value(playlist.getId()))
+                        .andExpect(jsonPath("$.data[0].username").value(member.getUsername()))
                         .andReturn().getResponse().getContentAsString()
         );
     }


### PR DESCRIPTION
## PR Checklist
아래의 조건을 확인하고 체크박스를 체크해주세요. 체크박스를 체크하지 않은 경우 PR이 머지되지 않을 수 있습니다.

- [X] 커밋 컨벤션을 지켜서 작성했는가?
- [X] 기능 추가의 경우 테스트 코드를 작성했는가?
- [ ] 기능 변경의 경우 문서를 업데이트했는가?
- [ ] 코드 리뷰를 진행했는가?


## PR Type
어떤 종류의 PR인지 체크박스를 체크해주세요.

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes


## What is the current behavior?
플레이리스트 조회 시 리스폰스에 유저네임 필드 부재

## What is the new behavior?
유저네임 추가


## Other information
이미지와 같은 PR과 관련된 추가적인 정보가 있다면 작성해주세요.

<img width="673" alt="스크린샷 2024-02-21 오후 1 33 25" src="https://github.com/CUK-CRUSH/Server/assets/62097643/52b96318-0f68-4f69-9888-e5cc8fcdad56">

플레이리스트 Response DTO 변경