### PR TITLE
Fix: 업데이트 로직 수정

### DIFF
--- a/src/main/java/crush/myList/domain/ranking/service/DailyMemberRankingService.java
+++ b/src/main/java/crush/myList/domain/ranking/service/DailyMemberRankingService.java
@@ -41,11 +41,15 @@ public class DailyMemberRankingService implements RankingService<MemberDto> {
         return convertToDtoList(memberRankings);
     }
 
+
+
     @Override
     @Scheduled(cron = "0 0 0 * * ?")
     public void updateRanking() {
         log.info("일간 유저 랭킹 업데이트");
         memberRankingRepository.deleteAll();
+        memberRankingRepository.flush();
+
         Pageable pageable = PageRequest.of(0, LimitConstants.MEMBER_RANKING_SIZE.getLimit());
 
         List<Member> bestMembers = memberRepository.findTopMembers(pageable).getContent();
@@ -74,6 +78,7 @@ public class DailyMemberRankingService implements RankingService<MemberDto> {
         return MemberDto.builder()
                 .id(memberRanking.getMember().getId())
                 .username(memberRanking.getMember().getUsername())
+                .introduction(memberRanking.getMember().getIntroduction())
                 .profileImageUrl(memberRanking.getMember().getProfileImage() == null ? null : memberRanking.getMember().getProfileImage().getUrl())
                 .build();
     }

--- a/src/main/java/crush/myList/domain/ranking/service/DailyMemberRankingService.java
+++ b/src/main/java/crush/myList/domain/ranking/service/DailyMemberRankingService.java
@@ -47,7 +47,7 @@ public class DailyMemberRankingService implements RankingService<MemberDto> {
     @Scheduled(cron = "0 0 0 * * ?")
     public void updateRanking() {
         log.info("일간 유저 랭킹 업데이트");
-        memberRankingRepository.deleteAll();
+        memberRankingRepository.deleteAllInBatch();
         memberRankingRepository.flush();
 
         Pageable pageable = PageRequest.of(0, LimitConstants.MEMBER_RANKING_SIZE.getLimit());

--- a/src/main/java/crush/myList/domain/ranking/service/DailyPlaylistRankingService.java
+++ b/src/main/java/crush/myList/domain/ranking/service/DailyPlaylistRankingService.java
@@ -1,5 +1,6 @@
 package crush.myList.domain.ranking.service;
 
+import crush.myList.domain.music.mongo.repository.MusicRepository;
 import crush.myList.domain.playlist.dto.PlaylistDto;
 import crush.myList.domain.playlist.entity.Playlist;
 import crush.myList.domain.playlist.repository.PlaylistLikeRepository;
@@ -28,6 +29,7 @@ public class DailyPlaylistRankingService implements RankingService<PlaylistDto.R
     private final PlaylistRankingRepository playlistRankingRepository;
     private final PlaylistRepository playlistRepository;
     private final PlaylistLikeRepository playlistLikeRepository;
+    private final MusicRepository musicRepository;
 
     @Override
     @PostConstruct
@@ -46,6 +48,8 @@ public class DailyPlaylistRankingService implements RankingService<PlaylistDto.R
     public void updateRanking() {
         log.info("일간 플레이리스트 랭킹 업데이트");
         playlistRankingRepository.deleteAll();
+        playlistRankingRepository.flush();
+
         Pageable pageable = PageRequest.of(0, LimitConstants.PLAYLIST_RANKING_SIZE.getLimit());
 
         List<Playlist> bestPlaylists = playlistRepository.findTopPlaylists(pageable).getContent();
@@ -76,6 +80,7 @@ public class DailyPlaylistRankingService implements RankingService<PlaylistDto.R
                 .playlistName(playlistRanking.getPlaylist().getName())
                 .username(playlistRanking.getPlaylist().getMember().getUsername())
                 .thumbnailUrl(playlistRanking.getPlaylist().getImage() == null ? null : playlistRanking.getPlaylist().getImage().getUrl())
+                .numberOfMusics(musicRepository.countByPlaylistId(playlistRanking.getPlaylist().getId()))
                 .likeCount(playlistRanking.getLikeCount())
                 .build();
     }

--- a/src/main/java/crush/myList/domain/ranking/service/DailyPlaylistRankingService.java
+++ b/src/main/java/crush/myList/domain/ranking/service/DailyPlaylistRankingService.java
@@ -47,7 +47,7 @@ public class DailyPlaylistRankingService implements RankingService<PlaylistDto.R
     @Scheduled(cron = "0 0 0 * * ?")
     public void updateRanking() {
         log.info("일간 플레이리스트 랭킹 업데이트");
-        playlistRankingRepository.deleteAll();
+        playlistRankingRepository.deleteAllInBatch();
         playlistRankingRepository.flush();
 
         Pageable pageable = PageRequest.of(0, LimitConstants.PLAYLIST_RANKING_SIZE.getLimit());

--- a/src/test/java/crush/myList/controller/RankingControllerTest.java
+++ b/src/test/java/crush/myList/controller/RankingControllerTest.java
@@ -34,7 +34,7 @@ public class RankingControllerTest {
     @Autowired
     private DailyMemberRankingService dailyMemberRankingService;
 
-    @DisplayName("랭킹 조회 테스트")
+    @DisplayName("랭킹 조회 테스트 - 업데이트 후 조회")
     @Test
     public void getRankingTest() throws Exception {
         // given
@@ -57,6 +57,11 @@ public class RankingControllerTest {
         final String USER_GET_API = "/api/v1/ranking/daily/users";
 
         // when
+        // 업데이트
+        dailyPlaylistRankingService.updateRanking();
+        dailyMemberRankingService.updateRanking();
+
+        // 조회
         mockMvc.perform(get(PLAYLIST_GET_API)
                         .header("Authorization", "Bearer " + jwtTokenProvider.createToken(member1.getId().toString(), JwtTokenType.ACCESS_TOKEN)))
                 .andExpect(status().isOk())

--- a/src/test/java/crush/myList/controller/TestUtil.java
+++ b/src/test/java/crush/myList/controller/TestUtil.java
@@ -182,7 +182,5 @@ public class TestUtil {
         musicRepository.deleteAll();
         playlistRepository.deleteAll();
         memberRepository.deleteAll();
-        playlistRankingRepository.deleteAll();
-        memberRankingRepository.deleteAll();
     }
 }


### PR DESCRIPTION
## PR Checklist
아래의 조건을 확인하고 체크박스를 체크해주세요. 체크박스를 체크하지 않은 경우 PR이 머지되지 않을 수 있습니다.

- [X] 커밋 컨벤션을 지켜서 작성했는가?
- [ ] 기능 추가의 경우 테스트 코드를 작성했는가?
- [ ] 기능 변경의 경우 문서를 업데이트했는가?
- [ ] 코드 리뷰를 진행했는가?


## PR Type
어떤 종류의 PR인지 체크박스를 체크해주세요.

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes


## What is the current behavior?
랭킹 테이블 delete 후 insert ->  SQL 순서로 인해 insert문이 먼저 실행되어 오류 발생

## What is the new behavior?
delete 후 flush하여 트랜잭션 처리 후 insert 하도록 변경
프론트엔드 요청으로 ranking api 반환값으로 몇몇 필드 추가


## Other information
이미지와 같은 PR과 관련된 추가적인 정보가 있다면 작성해주세요.

<img width="539" alt="스크린샷 2024-03-06 오후 2 26 54" src="https://github.com/CUK-CRUSH/Server/assets/62097643/c9297ea7-74ac-4193-ba5f-f24e63c952a5">

예시) 유저랭킹 삭제 후 플러시