### PR TITLE
Fix: 축제 매칭 신청 시 username 누락 검사가 없음

### DIFF
--- a/src/main/java/crush/myList/domain/festival/service/FestivalService.java
+++ b/src/main/java/crush/myList/domain/festival/service/FestivalService.java
@@ -18,6 +18,10 @@ public class FestivalService {
     private final FormRepository formRepository;
 
     private void checkUsername(FormData formData) {
+        // 사용자 이름이 설정되어 있는지 확인
+        if (formData.getUsername() == null || formData.getUsername().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "사용자 이름이 설정되지 않았습니다.");
+        }
         // 이미 신청한 사용자인지 확인
         if (formRepository.existsByUsername(formData.getUsername())) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "이미 신청한 사용자 입니다.");


### PR DESCRIPTION
## Description


## PR Checklist

- [x] 커밋 컨벤션을 지켜서 작성했는가?
- [ ] 기능 추가의 경우 테스트 코드를 작성했는가?
- [ ] 기능 변경의 경우 문서를 업데이트했는가?
- [ ] 코드 리뷰를 진행했는가?


## PR Type
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes


## What is the current behavior?
- username 중복만 검사

## What is the new behavior?
- username 누락 시 오류 반환

## Other information
![image](https://github.com/CUK-CRUSH/Server/assets/71076926/2f2ae8c3-90f2-4678-990c-276a7b49afbf)
