### PR TITLE
Refactor: 유튜브 비디오 검색 API 리팩터링

### DIFF
--- a/src/main/java/crush/myList/domain/search/controller/SearchController.java
+++ b/src/main/java/crush/myList/domain/search/controller/SearchController.java
@@ -12,7 +12,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -70,7 +69,7 @@ public class SearchController {
             @ApiResponse(responseCode = "500", description = "유튜브 API 할당량 모두 채움")
     })
     public JsonBody<List<VideoDto>> searchVideo(@RequestParam(name = "q") String q,
-                                                @RequestParam(name = "maxResults", defaultValue = "5", required = false) Long maxResults) {
+                                                @RequestParam(name = "maxResults", defaultValue = "5", required = false) Long maxResults) throws IOException{
         List<VideoDto> searchRes = searchService.searchVideos(q, maxResults);
         return JsonBody.of(HttpStatus.OK.value(),"검색 성공", searchRes);
     }

--- a/src/main/java/crush/myList/exception/ErrorCode.java
+++ b/src/main/java/crush/myList/exception/ErrorCode.java
@@ -14,7 +14,8 @@ public enum ErrorCode {
     NotFound(HttpStatus.NOT_FOUND, "해당 리소스를 찾을 수 없습니다."),
 
     NullPointer(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러입니다 - NullPointerException"),
-    DataIntegrityViolation(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러입니다 - DataIntegrityViolationException");
+    DataIntegrityViolation(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러입니다 - DataIntegrityViolationException"),
+    IOAccess(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러입니다 - IOException");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/crush/myList/exception/GlobalExceptionHandler.java
+++ b/src/main/java/crush/myList/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.io.IOException;
 import java.util.Arrays;
 
 @Slf4j(topic = "GlobalExceptionHandler")
@@ -27,5 +28,12 @@ public class GlobalExceptionHandler {
         // 데이터 무결성 위반 예외 처리
         log.error(e.getMessage());
         return ErrorResponse.toResponse(ErrorCode.DataIntegrityViolation);
+    }
+
+    @ExceptionHandler(IOException.class)
+    public ResponseBody handleIOException(IOException e) {
+        // 스트림 및 파일 입출력 엑세스 오류 예외 처리
+        log.error(e.getMessage());
+        return ErrorResponse.toResponse(ErrorCode.IOAccess);
     }
 }


### PR DESCRIPTION
## Description
유튜브 비디오 검색 API 리팩터링

## PR Checklist

- [x] 커밋 컨벤션을 지켜서 작성했는가?
- [ ] 기능 추가의 경우 테스트 코드를 작성했는가?
- [ ] 기능 변경의 경우 문서를 업데이트했는가?
- [ ] 코드 리뷰를 진행했는가?


## PR Type
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes


## What is the current behavior?
- 중첩 try-catch 문을 이용한 API 구현
- 가독성이 떨어짐

## What is the new behavior?
1. 중첩 try-catch 문을 제거하고 IOException에 대해 전역 예외처리 적용

2. YouTube Data API 객체 생성 및 설정 시 체인 형태로 변경
```SearchService.searchVideos```
   - Before<img width="761" alt="스크린샷 2024-04-16 오후 4 32 59" src="https://github.com/CUK-CRUSH/Server/assets/129057191/4572257b-e5a0-4324-abb7-55331dd5b865">
   
    - After <img width="736" alt="스크린샷 2024-04-16 오후 4 17 17" src="https://github.com/CUK-CRUSH/Server/assets/129057191/0aa2c973-32af-4989-8661-89ca4d649307">

3. requestYoutubeSearching 메소드에서 필요한 유튜브 검색 결과 목록을 한 번에 반환하도록 수정
```SearchService.requestYoutubeSearching```
   - Before <img width="925" alt="스크린샷 2024-04-16 오후 4 37 30" src="https://github.com/CUK-CRUSH/Server/assets/129057191/529aa66b-bfd7-45ec-b393-a90060bd1597">
    - After <img width="909" alt="스크린샷 2024-04-16 오후 4 22 25" src="https://github.com/CUK-CRUSH/Server/assets/129057191/38d9d70d-b6a1-4002-b9f8-79ba38cef7b1">

## Other information
close #209 



